### PR TITLE
fix: "smbstatus check fails on new systems"

### DIFF
--- a/usr/local/bin/autoshutdown.sh
+++ b/usr/local/bin/autoshutdown.sh
@@ -530,7 +530,7 @@ _check_net_status()
 
 	# Extra Samba-Check for connected Clients only if other processes are negative -> [ $NUMPROC -eq 0 ]
 	if [ $NUMPROC -eq 0 ]; then
-		if [ $(/usr/bin/smbstatus | egrep -i "no locked|sessionid.tdb not initialised" | wc -l) != "1" ]; then
+		if [ $(/usr/bin/smbstatus | egrep -i "no locked|sessionid.tdb not initialised|locking.tdb not initialised" | wc -l) != "1" ]; then
 			_log "INFO: Samba connected (reported by smbstatus) -> no shutdown"
 			let NUMPROC++
 		fi


### PR DESCRIPTION
For newer versions of smbstatus (Version 3.6.6) smbstatus will report
"/var/run/samba/locking.tdb not initialised" instead of "sessionid.tdb not
initialised". This commit enables the additional check for the "locking.tdb"
to enable autoshutdown again if Samba is not activated.
