### PR TITLE
Fixing syntax error preventing from logging into the WebGUI

### DIFF
--- a/usr/share/openmediavault/engined/module/autoshutdown.inc
+++ b/usr/share/openmediavault/engined/module/autoshutdown.inc
@@ -65,7 +65,7 @@ class OMVModuleAutoShutdown extends OMVModuleServiceAbstract
                 OMVErrorMsg::E_CONFIG_GET_OBJECT_FAILED,
                 $xPath
             );
-
+        }
         // Check if process is running. Init script does not support 'status'.
         $cmd = "ps --no-heading -C autoshutdown.sh";
         OMVUtil::exec($cmd, $output, $result);
@@ -111,3 +111,5 @@ OMVLogFile::registerType(
          )
     )
 );
+
+?>


### PR DESCRIPTION
The re-factoring of "autoshutdown.inc" in commit d1f29b3 introduced a syntax error which prevents from logging into the WebGUI.

"omv-engined -f -d" returns:
PHP Parse error:  syntax error, unexpected '$moduleMgr' (T_VARIABLE), expecting function (T_FUNCTION) in /usr/share/openmediavault/engined/module/autoshutdown.inc on line 94

The attached patch fixes that problem.
