### PR TITLE
Add transsmission download monitor

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Depends: fping,
          openmediavault (>= 3.0.40),
          pm-utils,
          sysstat,
+		 transmission-cli,
          ${misc:Depends}
 Conflicts: autoshutdown
 Priority: optional

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,6 @@ Depends: fping,
          openmediavault (>= 3.0.40),
          pm-utils,
          sysstat,
-		 transmission-cli,
          ${misc:Depends}
 Conflicts: autoshutdown
 Priority: optional

--- a/debian/postinst
+++ b/debian/postinst
@@ -28,34 +28,12 @@ case "$1" in
         SERVICE_XPATH_NAME="autoshutdown"
         SERVICE_XPATH="/config/services/${SERVICE_XPATH_NAME}"
 
-        if [ -z "$2" ]; then
+		echo "Updating configuration database ..."
+        omv-confdbadm create "conf.service.autoshutdown"
+        if [ -n "$2" ]; then
             deb-systemd-helper disable ${SERVICE_XPATH_NAME}.service >/dev/null || true
             deb-systemd-invoke stop ${SERVICE_XPATH_NAME}.service >/dev/null || true
-        fi
-
-        if ! omv_config_exists "${SERVICE_XPATH}"; then
-            omv_config_add_node "/config/services" "${SERVICE_XPATH_NAME}"
-            omv_config_add_key "${SERVICE_XPATH}" "enable" "0"
-            omv_config_add_key "${SERVICE_XPATH}" "cycles" "6"
-            omv_config_add_key "${SERVICE_XPATH}" "sleep" "180"
-            omv_config_add_key "${SERVICE_XPATH}" "range" "2..254"
-            omv_config_add_key "${SERVICE_XPATH}" "shutdowncommand" "0"
-            omv_config_add_key "${SERVICE_XPATH}" "checkclockactive" "0"
-            omv_config_add_key "${SERVICE_XPATH}" "uphours-begin" "6"
-            omv_config_add_key "${SERVICE_XPATH}" "uphours-end" "20"
-            omv_config_add_key "${SERVICE_XPATH}" "nsocketnumbers" "21,22,80,139,445,3689,6991,9091,49152"
-            omv_config_add_key "${SERVICE_XPATH}" "uldlcheck" "1"
-            omv_config_add_key "${SERVICE_XPATH}" "uldlrate" "50"
-            omv_config_add_key "${SERVICE_XPATH}" "loadaveragecheck" "0"
-            omv_config_add_key "${SERVICE_XPATH}" "loadaverage" "40"
-            omv_config_add_key "${SERVICE_XPATH}" "hddiocheck" "1"
-            omv_config_add_key "${SERVICE_XPATH}" "hddiorate" "401"
-            omv_config_add_key "${SERVICE_XPATH}" "checksamba" "1"
-            omv_config_add_key "${SERVICE_XPATH}" "checkcli" "1"
-            omv_config_add_key "${SERVICE_XPATH}" "syslog" "1"
-            omv_config_add_key "${SERVICE_XPATH}" "verbose" "0"
-            omv_config_add_key "${SERVICE_XPATH}" "fake" "0"
-            omv_config_add_key "${SERVICE_XPATH}" "extraoptions" ""
+			omv-confdbadm migrate "conf.service.autoshutdown" "${2}"
         fi
 
         omv-mkconf autoshutdown

--- a/etc/autoshutdown.default
+++ b/etc/autoshutdown.default
@@ -96,6 +96,9 @@ HDDIO_RATE=400
 CHECK_SAMBA="true"
     # If set to true, smbstatus will be checked for connected clients.
 
+TRANSMISSIONDOWNLOAD="false"
+	# Check transmission
+	
 CHECK_CLI="true"
     # If set to true, will check for connected users.
 

--- a/etc/autoshutdown.default
+++ b/etc/autoshutdown.default
@@ -96,8 +96,8 @@ HDDIO_RATE=400
 CHECK_SAMBA="true"
     # If set to true, smbstatus will be checked for connected clients.
 
-TRANSMISSIONDOWNLOAD="false"
-	# Check transmission
+TRANSMISSION_CHECK="false"
+	# Check transmission is downloading
 	
 CHECK_CLI="true"
     # If set to true, will check for connected users.

--- a/usr/sbin/autoshutdown.sh
+++ b/usr/sbin/autoshutdown.sh
@@ -948,6 +948,12 @@ _check_config()
 				_log "WARN: Set PLUGINCHECK to false"
 				PLUGINCHECK="false"; }
 	fi
+	
+	if [ ! -z "$TRANSMISSIONDOWNLOAD" ]; then
+		[[ "$TRANSMISSIONDOWNLOAD" = "true" || "$TRANSMISSIONDOWNLOAD" = "false" ]] || { _log "WARN: AUTOUNRARCHECK not set properly. It has to be 'true' or 'false'."
+				_log "WARN: Set TRANSMISSIONDOWNLOAD to false"
+				TRANSMISSIONDOWNLOAD="false"; }
+	fi
 
 	# Flag: 1 - 999 (cycles)
 	[[ "$CYCLES" =~ ^([1-9]|[1-9][0-9]|[1-9][0-9]{2})$ ]] || {

--- a/usr/sbin/autoshutdown.sh
+++ b/usr/sbin/autoshutdown.sh
@@ -476,7 +476,7 @@ _check_transmission()
 	
 	RVALUE=0
 	
-	if [ "$TRANSMISSIONDOWNLOAD" = "true" ] ; then
+	if [ "$TRANSMISSION_CHECK" = "true" ] ; then
 		
 		if [ -f /usr/bin/transmission-remote ]; then
 			# auth if needed
@@ -1000,10 +1000,10 @@ _check_config()
 				PLUGINCHECK="false"; }
 	fi
 	
-	if [ ! -z "$TRANSMISSIONDOWNLOAD" ]; then
-		[[ "$TRANSMISSIONDOWNLOAD" = "true" || "$TRANSMISSIONDOWNLOAD" = "false" ]] || { _log "WARN: AUTOUNRARCHECK not set properly. It has to be 'true' or 'false'."
-				_log "WARN: Set TRANSMISSIONDOWNLOAD to false"
-				TRANSMISSIONDOWNLOAD="false"; }
+	if [ ! -z "$TRANSMISSION_CHECK" ]; then
+		[[ "$TRANSMISSION_CHECK" = "true" || "$TRANSMISSION_CHECK" = "false" ]] || { _log "WARN: AUTOUNRARCHECK not set properly. It has to be 'true' or 'false'."
+				_log "WARN: Set TRANSMISSION_CHECK to false"
+				TRANSMISSION_CHECK="false"; }
 	fi
 
 	# Flag: 1 - 999 (cycles)
@@ -1478,7 +1478,7 @@ _check_system_active()
 	
 	if [ $CNT -eq 0 ]; then
 		# PRIO 8: Do a TRANSMISSION-Check
-		if [ "$TRANSMISSIONDOWNLOAD" = "true" ] ; then
+		if [ "$TRANSMISSION_CHECK" = "true" ] ; then
 			_check_transmission
 			if [ $? -gt 0 ]; then
 				let CNT++

--- a/usr/sbin/autoshutdown.sh
+++ b/usr/sbin/autoshutdown.sh
@@ -477,24 +477,30 @@ _check_transmission()
 	RVALUE=0
 	
 	if [ "$TRANSMISSIONDOWNLOAD" = "true" ] ; then
-		# auth if needed
-		auth="" #"--auth username:password"
-		torrentlist="transmission-remote --list "$auth
 		
-		count=$($torrentlist | cut -c25-31 | sed -e '/^Done/ d; /^Unknown/ d; 1d; $d')
-		
-		if $DEBUG; then
-			_log "DEBUG: -------------------------------------------"
-			_log "DEBUG: _check_transmission(): count downloading torrents: $count"
+		if [ -f /usr/bin/transmission-remote ]; then
+			# auth if needed
+			auth="" #"--auth username:password"
+			torrentlist="transmission-remote --list "$auth
 			
-		fi
-		
-		if [ -z "$count" ]; then
-			_log "INFO: Transmission no active downloads"
+			count=$($torrentlist | cut -c25-31 | sed -e '/^Done/ d; /^Unknown/ d; 1d; $d')
 			
+			if $DEBUG; then
+				_log "DEBUG: -------------------------------------------"
+				_log "DEBUG: _check_transmission(): count: $count"
+				
+			fi
+			
+			if [ -z "$count" ]; then
+				_log "INFO: Transmission no active downloads"
+				
+			else
+				_log "INFO: Transmission is downloading now"
+				let RVALUE++
+			fi
 		else
-			_log "INFO: Transmission is downloading now"
-			let RVALUE++
+			_log "INFO: Transmission check disabled. Not found /usr/bin/transmission-remote. Install transmission-cli package"
+			
 		fi
 	
 	fi

--- a/usr/sbin/autoshutdown.sh
+++ b/usr/sbin/autoshutdown.sh
@@ -460,6 +460,51 @@ _check_loadaverage()
 	return ${RVALUE}
 }
 
+
+################################################################
+#
+#   name         : _check_transmission
+#   parameter      : none
+#   global return   : none
+#   return         : 1      : if transmission-daemon is downloading torrents, no shutdown
+#               : 0      : if transmission-daemon is seeding only
+#
+# This script use transmission-remote from transmission-cli package
+
+_check_transmission()
+{
+	
+	RVALUE=0
+	
+	if [ "$TRANSMISSIONDOWNLOAD" = "true" ];
+		# auth if needed
+		auth="" #"--auth username:password"
+		torrentlist="transmission-remote --list "$auth
+		
+		count=$($torrentlist | cut -c25-31 | sed -e '/^Done/ d; /^Unknown/ d; 1d; $d')
+		
+		if $DEBUG; then
+			_log "DEBUG: -------------------------------------------"
+			_log "DEBUG: _check_transmission(): count downloading torrents: $count"
+			
+		fi
+		
+		if [ -z "$count" ]; then
+			_log "INFO: Transmission no active downloads"
+			
+		else
+			_log "INFO: Transmission is downloading now"
+			let RVALUE++
+		fi
+	
+	fi
+	
+	return ${RVALUE}
+	
+	
+}
+
+
 ################################################################
 #
 #   name         : _check_net_status

--- a/usr/sbin/autoshutdown.sh
+++ b/usr/sbin/autoshutdown.sh
@@ -476,7 +476,7 @@ _check_transmission()
 	
 	RVALUE=0
 	
-	if [ "$TRANSMISSIONDOWNLOAD" = "true" ];
+	if [ "$TRANSMISSIONDOWNLOAD" = "true" ] ; then
 		# auth if needed
 		auth="" #"--auth username:password"
 		torrentlist="transmission-remote --list "$auth
@@ -1453,7 +1453,9 @@ _check_system_active()
 	else
 		if $DEBUG ; then _log "DEBUG: _check_system_active(): _check_loadaverage not called -> CNT: $CNT "; fi
 	fi   # > if[ $CNT -eq 0 ]; then
-
+	
+	
+	
 	if [ $CNT -eq 0 ]; then
 		# PRIO 7: Do a PlugIn-Check for any existing files, setup in plugins
 		if [ "$PLUGINCHECK" = "true" ] ; then
@@ -1467,6 +1469,20 @@ _check_system_active()
 	else
 		if $DEBUG ; then _log "DEBUG: _check_system_active(): _check_plugin not called -> CNT: $CNT "; fi
 	fi   # > if[ $CNT -eq 0 ]; then
+	
+	if [ $CNT -eq 0 ]; then
+		# PRIO 8: Do a TRANSMISSION-Check
+		if [ "$TRANSMISSIONDOWNLOAD" = "true" ] ; then
+			_check_transmission
+			if [ $? -gt 0 ]; then
+				let CNT++
+			fi
+
+			if $DEBUG ; then _log "DEBUG: _check_transmission(): call _check_transmission -> CNT: $CNT "; fi
+		fi
+	else
+		if $DEBUG ; then _log "DEBUG: _check_transmission(): _check_transmission not called -> CNT: $CNT "; fi
+	fi   
 
 	return ${CNT};
 }

--- a/usr/share/openmediavault/confdb/create.d/conf.service.autoshutdown.sh
+++ b/usr/share/openmediavault/confdb/create.d/conf.service.autoshutdown.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @author    OpenMediaVault Plugin Developers <plugins@omv-extras.org>
+# @copyright Copyright (c) 2009-2013 Volker Theile
+# @copyright Copyright (c) 2013-2017 OpenMediaVault Plugin Developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+set -e
+
+. /usr/share/openmediavault/scripts/helper-functions
+
+SERVICE_XPATH_NAME="autoshutdown"
+SERVICE_XPATH="/config/services/${SERVICE_XPATH_NAME}"
+
+if ! omv_config_exists "${SERVICE_XPATH}"; then
+            omv_config_add_node "/config/services" "${SERVICE_XPATH_NAME}"
+            omv_config_add_key "${SERVICE_XPATH}" "enable" "0"
+            omv_config_add_key "${SERVICE_XPATH}" "cycles" "6"
+            omv_config_add_key "${SERVICE_XPATH}" "sleep" "180"
+            omv_config_add_key "${SERVICE_XPATH}" "range" "2..254"
+            omv_config_add_key "${SERVICE_XPATH}" "shutdowncommand" "0"
+            omv_config_add_key "${SERVICE_XPATH}" "checkclockactive" "0"
+            omv_config_add_key "${SERVICE_XPATH}" "uphours-begin" "6"
+            omv_config_add_key "${SERVICE_XPATH}" "uphours-end" "20"
+            omv_config_add_key "${SERVICE_XPATH}" "nsocketnumbers" "21,22,80,139,445,3689,6991,9091,49152"
+            omv_config_add_key "${SERVICE_XPATH}" "uldlcheck" "1"
+            omv_config_add_key "${SERVICE_XPATH}" "uldlrate" "50"
+            omv_config_add_key "${SERVICE_XPATH}" "loadaveragecheck" "0"
+            omv_config_add_key "${SERVICE_XPATH}" "loadaverage" "40"
+            omv_config_add_key "${SERVICE_XPATH}" "hddiocheck" "1"
+            omv_config_add_key "${SERVICE_XPATH}" "hddiorate" "401"
+            omv_config_add_key "${SERVICE_XPATH}" "checksamba" "1"
+            omv_config_add_key "${SERVICE_XPATH}" "checkcli" "1"
+            omv_config_add_key "${SERVICE_XPATH}" "syslog" "1"
+            omv_config_add_key "${SERVICE_XPATH}" "verbose" "0"
+            omv_config_add_key "${SERVICE_XPATH}" "fake" "0"
+            omv_config_add_key "${SERVICE_XPATH}" "extraoptions" ""
+        fi
+
+exit 0

--- a/usr/share/openmediavault/confdb/delete.d/conf.service.autoshutdown.sh
+++ b/usr/share/openmediavault/confdb/delete.d/conf.service.autoshutdown.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+. /usr/share/openmediavault/scripts/helper-functions
+
+SERVICE_XPATH_NAME="letsencrypt"
+SERVICE_XPATH="/config/services/${SERVICE_XPATH_NAME}"
+
+if omv_config_exists "${SERVICE_XPATH}"; then
+    omv_config_delete "${SERVICE_XPATH}"
+fi
+
+exit 0

--- a/usr/share/openmediavault/confdb/delete.d/conf.service.autoshutdown.sh
+++ b/usr/share/openmediavault/confdb/delete.d/conf.service.autoshutdown.sh
@@ -4,7 +4,7 @@ set -e
 
 . /usr/share/openmediavault/scripts/helper-functions
 
-SERVICE_XPATH_NAME="letsencrypt"
+SERVICE_XPATH_NAME="autoshutdown"
 SERVICE_XPATH="/config/services/${SERVICE_XPATH_NAME}"
 
 if omv_config_exists "${SERVICE_XPATH}"; then

--- a/usr/share/openmediavault/confdb/migrations.d/conf.service.autoshutdown_4.0.3.sh
+++ b/usr/share/openmediavault/confdb/migrations.d/conf.service.autoshutdown_4.0.3.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @author    OpenMediaVault Plugin Developers <plugins@omv-extras.org>
+# @copyright Copyright (c) 2009-2013 Volker Theile
+# @copyright Copyright (c) 2013-2017 OpenMediaVault Plugin Developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+set -e
+
+. /usr/share/openmediavault/scripts/helper-functions
+
+SERVICE_XPATH_NAME="autoshutdown"
+SERVICE_XPATH="/config/services/${SERVICE_XPATH_NAME}"
+
+if ! omv_config_exists "${SERVICE_XPATH}/transmissioncheck"; then
+    omv_config_add_key "${SERVICE_XPATH}" "transmissioncheck" "0"
+fi
+
+exit 0

--- a/usr/share/openmediavault/datamodels/conf.service.autoshutdown.json
+++ b/usr/share/openmediavault/datamodels/conf.service.autoshutdown.json
@@ -87,6 +87,10 @@
 			"type": "boolean",
 			"default": true
 		},
+		"transmissiondownload": {
+			"type": "boolean",
+			"default": false
+		},
 		"checkcli": {
 			"type": "boolean",
 			"default": true

--- a/usr/share/openmediavault/datamodels/conf.service.autoshutdown.json
+++ b/usr/share/openmediavault/datamodels/conf.service.autoshutdown.json
@@ -87,7 +87,7 @@
 			"type": "boolean",
 			"default": true
 		},
-		"transmissiondownload": {
+		"transmissioncheck": {
 			"type": "boolean",
 			"default": false
 		},

--- a/usr/share/openmediavault/datamodels/rpc.autoshutdown.json
+++ b/usr/share/openmediavault/datamodels/rpc.autoshutdown.json
@@ -84,6 +84,10 @@
 				"type": "boolean",
 				"required": true
 			},
+			"transmissiondownload": {
+			"type": "boolean",
+			"default": false
+			},
 			"checkcli": {
 				"type": "boolean",
 				"required": true

--- a/usr/share/openmediavault/datamodels/rpc.autoshutdown.json
+++ b/usr/share/openmediavault/datamodels/rpc.autoshutdown.json
@@ -84,7 +84,7 @@
 				"type": "boolean",
 				"required": true
 			},
-			"transmissiondownload": {
+			"transmissioncheck": {
 			"type": "boolean",
 			"default": false
 			},

--- a/usr/share/openmediavault/mkconf/autoshutdown
+++ b/usr/share/openmediavault/mkconf/autoshutdown
@@ -63,7 +63,7 @@ xmlstarlet sel -t \
         -i "fake = 0" -o "FAKE=\"false\"" -n -b \
         -i "fake = 1" -o "FAKE=\"true\"" -n -b \
         -i "string-length(extraoptions) > 0" -v "extraoptions" -n -b \
-		-i "transmissiondownload = 0" -o "TRANSMISSIONDOWNLOAD=\"false\"" -n -b \
-        -i "transmissiondownload = 1" -o "TRANSMISSIONDOWNLOAD=\"true\"" -n -b \
+		-i "transmissioncheck = 0" -o "TRANSMISSION_CHECK=\"false\"" -n -b \
+        -i "transmissioncheck = 1" -o "TRANSMISSION_CHECK=\"true\"" -n -b \
     -b \
     ${OMV_CONFIG_FILE} | xmlstarlet unesc > ${AUTOSHUTDOWN_CONFIG}

--- a/usr/share/openmediavault/mkconf/autoshutdown
+++ b/usr/share/openmediavault/mkconf/autoshutdown
@@ -63,5 +63,7 @@ xmlstarlet sel -t \
         -i "fake = 0" -o "FAKE=\"false\"" -n -b \
         -i "fake = 1" -o "FAKE=\"true\"" -n -b \
         -i "string-length(extraoptions) > 0" -v "extraoptions" -n -b \
+		-i "transmissiondownload = 0" -o "TRANSMISSIONDOWNLOAD=\"false\"" -n -b \
+        -i "transmissiondownload = 1" -o "TRANSMISSIONDOWNLOAD=\"true\"" -n -b \
     -b \
     ${OMV_CONFIG_FILE} | xmlstarlet unesc > ${AUTOSHUTDOWN_CONFIG}

--- a/var/www/openmediavault/js/omv/module/admin/service/autoshutdown/Settings.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/autoshutdown/Settings.js
@@ -289,6 +289,12 @@ Ext.define("OMV.module.admin.service.autoshutdown.Settings", {
                 fieldLabel : _("Check smbstatus"),
                 checked    : true,
                 boxLabel   : _("Check smbstatus for connected clients.")
+			},{
+                xtype      : "checkbox",
+                name       : "transmissiondownload",
+                fieldLabel : _("Check transmission"),
+                checked    : true,
+                boxLabel   : _("Check transmission for downloading torrents.")
             },{
                 xtype      : "checkbox",
                 name       : "checkcli",

--- a/var/www/openmediavault/js/omv/module/admin/service/autoshutdown/Settings.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/autoshutdown/Settings.js
@@ -293,7 +293,7 @@ Ext.define("OMV.module.admin.service.autoshutdown.Settings", {
                 xtype      : "checkbox",
                 name       : "transmissioncheck",
                 fieldLabel : _("Check transmission"),
-                checked    : true,
+                checked    : false,
                 boxLabel   : _("Check transmission for downloading torrents.")
             },{
                 xtype      : "checkbox",

--- a/var/www/openmediavault/js/omv/module/admin/service/autoshutdown/Settings.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/autoshutdown/Settings.js
@@ -291,7 +291,7 @@ Ext.define("OMV.module.admin.service.autoshutdown.Settings", {
                 boxLabel   : _("Check smbstatus for connected clients.")
 			},{
                 xtype      : "checkbox",
-                name       : "transmissiondownload",
+                name       : "transmissioncheck",
                 fieldLabel : _("Check transmission"),
                 checked    : true,
                 boxLabel   : _("Check transmission for downloading torrents.")


### PR DESCRIPTION
Hi!
I know that such do not like. But I added monitoring that the transmission downloads torrents.
Tested only that when there are no downloads, the computer turns off. Actions during download is not tested.
I did not make the package, I updated the plug-in files manually.
Dependence on the transmission-cli package appeared.
Authorization transmission is not used, but can be easily added.
OMV4 Arrakis, debian 9 strech
