### PR TITLE
Fix issue HDDIO only look for sda #24

### DIFF
--- a/usr/sbin/autoshutdown.sh
+++ b/usr/sbin/autoshutdown.sh
@@ -800,7 +800,7 @@ _check_hddio()
 		_log "DEBUG: ## iostat -kd ## End ----------"
 	fi
 
-	for OMV_HDD in $(mount -l | grep /dev/sd | sed 's/.*\(sd.\).*/\1/g' | sort -u); do
+	for OMV_HDD in $(lsblk --output MOUNTPOINT,PKNAME | grep "/" | sed 's/.*\(sd.\).*/\1/g' | sort -u); do
 		OMV_IOSTAT="$(egrep ^${OMV_HDD} $HDDIOTMPDIR/iostat.txt)"
 
 		OMV_ASD_HDD_IN="$(echo "$OMV_IOSTAT" | awk '{print $5}')"


### PR DESCRIPTION
I encountered the same issue using a LVM. Devices that are part of a volume group are not taken into account by the _check_hddio() function.
I found a solution using the lsblk command keeping as close as the original command line in the for loop.