### PR TITLE
Fix logging regression

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-autoshutdown (5.0.6) stable; urgency=low
+
+  * Fix regression in logging
+
+ -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Thu, 28 Sep 2020 20:00:51 +0100
+
 openmediavault-autoshutdown (5.0.5) stable; urgency=low
 
   * Fix indentation: debian/postinst

--- a/etc/rsyslog.d/autoshutdown.conf
+++ b/etc/rsyslog.d/autoshutdown.conf
@@ -1,3 +1,3 @@
 # All log-entries from autoshutdown are going into /var/log/autoshutdown.log
-if $programname == 'autoshutdown' then /var/log/autoshutdown.log
+:msg, contains, "autoshutdown[" /var/log/autoshutdown.log
 & stop


### PR DESCRIPTION
Logging is not working correctly in the new package and log are
going to messages. This change fixed the rsyslog config to correct
the issue.