### PR TITLE
Fix 'Shutdown Command' combo value validation

### DIFF
--- a/usr/share/openmediavault/datamodels/conf.service.autoshutdown.json
+++ b/usr/share/openmediavault/datamodels/conf.service.autoshutdown.json
@@ -34,7 +34,7 @@
 		"shutdowncommand": {
 			"type": "integer",
 			"minimum": 0,
-			"maximum": 3,
+			"maximum": 4,
 			"default": 0
 		},
 		"checkclockactive": {

--- a/usr/share/openmediavault/datamodels/rpc.autoshutdown.json
+++ b/usr/share/openmediavault/datamodels/rpc.autoshutdown.json
@@ -31,7 +31,7 @@
 			"shutdowncommand": {
 				"type": "integer",
 				"minimum": 0,
-				"maximum": 3,
+				"maximum": 4,
 				"required": true
 			},
 			"checkclockactive": {


### PR DESCRIPTION
Suspend-then-Hibernate option made possible to save from settings page.

Hey! Here it is provided a little fix for a lovely plugin from an OMV newbie. Hopefully these are all the changes needed to have validation fixed.