### PR TITLE
Fix indention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ debian/files
 debian/*.debhelper.log
 debian/*.debhelper
 debian/*substvars
+
+# PyCharm
+/.idea/

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Architecture: all
 Depends: fping,
          jq,
          net-tools,
-         openmediavault (>= 6.0),
+         openmediavault (>= 6.7.0),
          pm-utils,
          sysstat,
          ${misc:Depends}

--- a/usr/share/openmediavault/workbench/component.d/omv-services-autoshutdown-form-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-services-autoshutdown-form-page.yaml
@@ -192,7 +192,7 @@ data:
             name: ipcheck
             label: _("IP-Range")
             value: true
-            flex: 17
+            flex: 20
           - type: textarea
             name: range
             value: 2..254,0x0..0xFFFF
@@ -216,7 +216,7 @@ data:
             name: checksockets
             label: _("Sockets")
             value: true
-            flex: 17
+            flex: 20
           - type: textarea
             name: nsocketnumbers
             value: 21,22,80,3689,6991,9091,49152
@@ -244,7 +244,7 @@ data:
             name: uldlcheck
             label: _("ULDL Rate")
             value: true
-            flex: 17
+            flex: 20
           - type: numberInput
             name: uldlrate
             label: _("kB/s")
@@ -270,7 +270,7 @@ data:
             name: hddiocheck
             label: _("HDD-IO")
             value: true
-            flex: 17
+            flex: 20
           - type: numberInput
             name: hddiorate
             label: _("kB/s")
@@ -296,7 +296,7 @@ data:
             name: loadaveragecheck
             label: _("Load Average")
             value: false
-            flex: 17
+            flex: 20
           - type: numberInput
             name: loadaverage
             label: _("Load average")
@@ -323,7 +323,7 @@ data:
             name: checkprocnames
             label: _("Active Processes")
             value: true
-            flex: 17
+            flex: 20
           - type: textarea
             name: loadprocnames
             label: _("Load processes")
@@ -348,7 +348,7 @@ data:
       - type: container
         fields:
           - type: paragraph
-            flex: 17
+            flex: 20
           - type: textarea
             name: tempprocnames
             label: _("Temp processes")


### PR DESCRIPTION
With openmediavault 6.7.0 the `flex` property only supports a limited number of predefined values.

References:
- https://github.com/openmediavault/openmediavault/blob/master/deb/openmediavault/workbench/src/app/core/components/intuition/models/form-field-config.type.ts#L175
- https://forum.openmediavault.org/index.php?thread/49789-representation-in-the-autoshutdown-plugin/&postID=368254#post368254