### PR TITLE
get all IPv6 addresses and check connections on all of them

### DIFF
--- a/usr/sbin/autoshutdown
+++ b/usr/sbin/autoshutdown
@@ -1307,7 +1307,7 @@ _get_network_details() {
                 local valid="false" regex="R_${ip_type^^}"
                 local ip; ip="$(LC_ALL=C
                     ip -br -"${ip_type: -1}" addr show dev "${net_iface}" | sed 's/.*  //' |
-                    awk '{tolower($0);gsub(/\/[0-9]+/,""); sub(" fe80.* ",""); $1=$1; print}')"
+                    awk '{tolower($0);gsub(/\/[0-9]+/,"");gsub(/ metric [0-9]+/,"");sub(" fe80.* ",""); $1=$1; print}')"
                 msg+="IPv${ip_type: -1} address: ${ip:-N/A}, "
                 [[ "${state}" =~ ^(unknown|dormant|up)$ ]] && {
                     declare -n ip_ref="NIC_2_${ip_type^^}[${net_iface}]"

--- a/usr/sbin/autoshutdown
+++ b/usr/sbin/autoshutdown
@@ -1306,15 +1306,14 @@ _get_network_details() {
             for ip_type in ipv4 ipv6; do
                 local valid="false" regex="R_${ip_type^^}"
                 local ip; ip="$(LC_ALL=C
-                    ip -br -"${ip_type: -1}" addr show dev "${net_iface}" |
-                    awk '{sub(/\/[0-9]+$/,"",$3); print $3}')"
+                    ip -br -"${ip_type: -1}" addr show dev "${net_iface}" | sed 's/.*  //' |
+                    awk '{tolower($0);gsub(/\/[0-9]+/,""); sub(" fe80.* ",""); $1=$1; print}')"
                 msg+="IPv${ip_type: -1} address: ${ip:-N/A}, "
-                [[ "${ip}" =~ ^(${!regex})$ ]] && {
-                    [[ "${state}" =~ ^(unknown|dormant|up)$ ]] && {
-                        declare -n ip_ref="NIC_2_${ip_type^^}[${net_iface}]"
-                        # shellcheck disable=SC2034
-                        ip_ref="${ip}"; }
-                    valid="true"; }
+                [[ "${state}" =~ ^(unknown|dormant|up)$ ]] && {
+                    declare -n ip_ref="NIC_2_${ip_type^^}[${net_iface}]"
+                    # shellcheck disable=SC2034
+                    ip_ref="${ip}"; }
+                valid="true";
                 _log "DEBUG: Network interfaces IPv${ip_type: -1} address: ${ip:-N/A}"
                 _log "DEBUG: Network interfaces IPv${ip_type: -1} address valid: ${valid}"
             done
@@ -1371,7 +1370,7 @@ _check_system_active() {
         # PRIO 1: Ping IP address specified across active network interfaces.
         __run_check "${IPCHECK}" _ping_range "${net_iface}" \
             "${NIC_2_IPV4["${net_iface}"]:-}" \
-            "${NIC_2_IPV6["${net_iface}"]:-}" \
+            "${NIC_2_IPV6["${net_iface}"]%% *}" \
             "${ips}" || return 1
     done
 


### PR DESCRIPTION
I've encountered the following issue with omv 6 and Mac clients.

Network interfaces can have multiple IPv6 addresses, besides the link local address. The current implemantation with 'ip -br -6 addr show dev <interface>' only returns the first of them.

As it's possible that a client will use another IPv6 of the same interface, any check for established connections will fail if the client uses an IPv6 not reported by the 'ip' command.

Especially Macs may suffer from that issue.

Announcing services via avahi may announce IPv6 addresses in other sorting order than 'ip' does. AFAIK, Macs will pick the first IPv6 address announced by avahi.

This PR will fix this issue.

In _get_network_details() all IPv6 addresses will be retrieved by a slightly modified 'ip' command line. As we can safely assume, that addresses returned by 'ip' are valid, no check against a regex is needed.

The 3rd parameter of _ping_range() will only use the first IPv6 address, which is sufficient and identical to the current implementation.

