### PR TITLE
Fix smartctl check issue

### DIFF
--- a/usr/sbin/autoshutdown
+++ b/usr/sbin/autoshutdown
@@ -999,7 +999,7 @@ _check_smart() {
         _log "DEBUG: Checking device for running smart tests: ${hdd}"
 
         local smart_output; smart_output="$(LC_ALL=C
-            smartctl --all --nocheck=standby "${hdd}" || true)"
+            smartctl --all --nocheck=standby "/dev/${hdd}" || true)"
 
         _log "DEBUG: Smartctl output: ${hdd}"
         local line; while read -r line; do


### PR DESCRIPTION
Version 7.0 doesn't work for S.M.A.R.T. checks. The debug was saying that device "sda" does not exist. Changing the check to "/dev/${hdd}" fixes this.
```sh
smartctl --all --nocheck=standby sda
smartctl 7.3 2022-02-28 r5338 [x86_64-linux-6.8.12-2-pve] (local build)
Copyright (C) 2002-22, Bruce Allen, Christian Franke, www.smartmontools.org

Smartctl open device: sda failed: No such device
```

```sh
smartctl --all --nocheck=standby /dev/sda
smartctl 7.3 2022-02-28 r5338 [x86_64-linux-6.8.12-2-pve] (local build)
Copyright (C) 2002-22, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
...
```