### PR TITLE
Enhance HDD check logic in autoshutdown script

### DIFF
--- a/usr/sbin/autoshutdown
+++ b/usr/sbin/autoshutdown
@@ -904,11 +904,16 @@ _check_hddio() {
     local hdd hdd_in hdd_out; while read -r hdd hdd_in hdd_out; do
         _log "DEBUG: ========== Device: ${hdd} =========="
 
-        ! mount -l | grep -q "${hdd}" &&
-            command -v zpool >/dev/null 2>&1 &&
-            ! ZPOOL_SCRIPTS_AS_ROOT=1 zpool status -c upath | grep "${hdd}" | grep -q -e "ONLINE" -e "DEGRADED" && {
+        if ! mount -l | grep -q -- "${hdd}"; then
+            if ! command -v zpool >/dev/null 2>&1 ||
+               ! ZPOOL_SCRIPTS_AS_ROOT=1 zpool status -c upath 2>/dev/null |
+                    grep -F -- "${hdd}" |
+                    grep -qE 'ONLINE|DEGRADED'
+            then
                 _log "DEBUG: Skipping as no mount point"
-                continue; }
+                continue
+            fi
+        fi
 
         local line; while read -r line; do
             _log "DEBUG: ${line}"

--- a/usr/sbin/autoshutdown
+++ b/usr/sbin/autoshutdown
@@ -904,9 +904,11 @@ _check_hddio() {
     local hdd hdd_in hdd_out; while read -r hdd hdd_in hdd_out; do
         _log "DEBUG: ========== Device: ${hdd} =========="
 
-        ! mount -l | grep -q "${hdd}" && {
-            _log "DEBUG: Skipping as no mount point"
-            continue; }
+        ! mount -l | grep -q "${hdd}" &&
+            command -v zpool >/dev/null 2>&1 &&
+            ! ZPOOL_SCRIPTS_AS_ROOT=1 zpool status -c upath | grep "${hdd}" | grep -q -e "ONLINE" -e "DEGRADED" && {
+                _log "DEBUG: Skipping as no mount point"
+                continue; }
 
         local line; while read -r line; do
             _log "DEBUG: ${line}"


### PR DESCRIPTION
The current hdd check does not check disks that are part of a ZFS pool. This change fixes this. For an explanation, see the issue https://github.com/OpenMediaVault-Plugin-Developers/openmediavault-autoshutdown/issues/132