### PR TITLE
fix 'RTNETLINK answers: Invalid argument' warning in check_net_status()

### DIFF
--- a/usr/sbin/autoshutdown
+++ b/usr/sbin/autoshutdown
@@ -480,7 +480,7 @@ _check_net_status() {
     # For each socket see if it is stated active using ss command.
     for nsocket in ${NSOCKETNUMBERS//,/ }; do
         local lines; lines="$(LC_ALL=C
-            ss state established --no-header \
+            ss -tu state established --no-header \
                 "( sport ${nsocket} and ( src [${ips_filter}] ) \
                     ${ips_ignore:-} )" )"
 


### PR DESCRIPTION
Although check_net_status() works as expected, the call of `ss`  gives a warning 'RTNETLINK answers: Invalid argument'

```
2026-01-21T15:13:02.920262+01:00 spacestation autoshutdown[16879]: root: DEBUG: '__run_check(): Calling: _check_net_status()'
2026-01-21T15:13:02.936479+01:00 spacestation autoshutdown[17399]: RTNETLINK answers: Invalid argument
2026-01-21T15:13:02.941982+01:00 spacestation autoshutdown[16879]: root: DEBUG: '_check_net_status(): Port 22: Found active connections:'
2026-01-21T15:13:02.951815+01:00 spacestation autoshutdown[16879]: root: DEBUG: '_check_net_status(): tcp 0 164 192.168.10.106:ssh 192.168.10.176:49945'
2026-01-21T15:13:02.965401+01:00 spacestation autoshutdown[16879]: root: INFO: '_check_net_status(): Found 1 active connection(s) on port 22 (SSH) from: 192.168.10.176'
```

This PR fixes that.